### PR TITLE
feat/screen tone

### DIFF
--- a/src/assets/styles/scss/modules/theme.module.scss
+++ b/src/assets/styles/scss/modules/theme.module.scss
@@ -14,3 +14,9 @@ $frame-stroke-color: $primary-text-color;
 $frame-stroke-width: 1px;
 
 // #endregion
+
+// #region Screen-Tone
+$screen-tone-dot-color: $primary-text-color;
+$screen-tone-dot-stroke-width: $frame-stroke-width;
+
+// #endregion

--- a/src/modules/components/Element/MainFrame.vue
+++ b/src/modules/components/Element/MainFrame.vue
@@ -345,13 +345,13 @@ const framePath = computed(
 `
 );
 
-const calcVariables = () => {
+const measureBoundingBox = () => {
   width.value = wrapperRef$.value?.offsetWidth || 0;
   height.value = wrapperRef$.value?.offsetHeight || 0;
 };
 
 onMounted(() => {
-  calcVariables();
+  measureBoundingBox();
 });
 </script>
 

--- a/src/modules/components/Element/MainFrame.vue
+++ b/src/modules/components/Element/MainFrame.vue
@@ -371,8 +371,7 @@ onMounted(() => {
         :class="$style['main-frame--path']"
         :d="framePath"
         fill="transparent"
-        stroke="current
-        C olor"
+        stroke="currentColor"
         stroke-linecap="round"
         stroke-linejoin="round"
       />

--- a/src/modules/components/Element/MainFrame.vue
+++ b/src/modules/components/Element/MainFrame.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
-import { onMounted, ref, computed } from 'vue';
+import { ref, computed } from 'vue';
+import { useElementSize } from '@vueuse/core';
 
 import Math$ from '@/shared/libs/math';
 
 import type { Vector } from '@/shared/types/vector';
 
 const wrapperRef$ = ref<HTMLElement>();
-const width = ref(0);
-const height = ref(0);
+const { width, height } = useElementSize(wrapperRef$);
+
 const bottomRightSpaceSize = ref(240);
 const bottomLeftCornerSize = ref(60);
 const leftMiddleSpaceSize = ref(420);
@@ -344,15 +345,6 @@ const framePath = computed(
   Z
 `
 );
-
-const measureBoundingBox = () => {
-  width.value = wrapperRef$.value?.offsetWidth || 0;
-  height.value = wrapperRef$.value?.offsetHeight || 0;
-};
-
-onMounted(() => {
-  measureBoundingBox();
-});
 </script>
 
 <template>

--- a/src/modules/components/Element/ScreenTone.vue
+++ b/src/modules/components/Element/ScreenTone.vue
@@ -1,9 +1,25 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, computed } from 'vue';
+
+import Math$ from '@/shared/libs/math';
 
 const wrapperRef$ = ref<HTMLElement>();
 const width = ref(0);
 const height = ref(0);
+
+const dotSize = ref(5);
+const dotGapBase = ref(1);
+const dotGap = computed(() => {
+  const maxGap = Math$.gcd(width.value, height.value);
+
+  return Math$.clamp(
+    maxGap > dotSize.value * (5 * dotGapBase.value)
+      ? Math$.gcd(maxGap, dotSize.value * (5 * dotGapBase.value))
+      : Math$.lcm(maxGap, dotSize.value * (5 * dotGapBase.value)),
+    dotSize.value * (4 * dotGapBase.value),
+    dotSize.value * (6 * dotGapBase.value)
+  );
+});
 
 const measureBoundingBox = () => {
   width.value = wrapperRef$.value?.offsetWidth || 0;
@@ -16,7 +32,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div ref="wrapperRef$" class="screen-tone-wrapper">
+  <div ref="wrapperRef$" :class="$style['screen-tone--wrapper']">
     <svg
       :width="width"
       :height="height"
@@ -27,6 +43,38 @@ onMounted(() => {
     >
       <defs></defs>
       <rect x="0" y="0" width="100%" height="100%" fill="transparent" />
+      <template v-for="x in width / dotGap">
+        <template v-for="y in height / dotGap">
+          <template v-if="x % 2 === 0 && y % 2 === 0">
+            <path
+              :key="`dot-${x}-${y}`"
+              :d="`
+                M ${(x - 1) * dotGap} ${(y - 1) * dotGap - dotSize / 2}
+                v ${dotSize}
+                m ${dotSize / -2} ${dotSize / -2}
+                h ${dotSize}`"
+              :class="$style['screen-tone--path']"
+            />
+          </template>
+        </template>
+      </template>
     </svg>
   </div>
 </template>
+
+<style module lang="scss" scoped>
+@use '@/assets/styles/scss/modules/theme.module' as theme;
+
+.screen-tone {
+  &--wrapper {
+    position: absolute;
+    width: 100%;
+    height: 100vh;
+  }
+
+  &--path {
+    stroke: #{theme.$screen-tone-dot-color};
+    stroke-width: #{theme.$screen-tone-dot-stroke-width};
+  }
+}
+</style>

--- a/src/modules/components/Element/ScreenTone.vue
+++ b/src/modules/components/Element/ScreenTone.vue
@@ -1,34 +1,22 @@
 <script setup lang="ts">
-import { onMounted, ref, computed } from 'vue';
+import { ref, computed, reactive } from 'vue';
+import { useElementSize, useMouse } from '@vueuse/core';
 
 import Math$ from '@/shared/libs/math';
 
+const $mouse = reactive(
+  useMouse({
+    type: 'client',
+    resetOnTouchEnds: true
+  })
+);
+
 const wrapperRef$ = ref<HTMLElement>();
-const width = ref(0);
-const height = ref(0);
+const { width, height } = useElementSize(wrapperRef$);
 
 const dotSize = ref(5);
-const dotGapBase = ref(1);
-const dotGap = computed(() => {
-  const maxGap = Math$.gcd(width.value, height.value);
-
-  return Math$.clamp(
-    maxGap > dotSize.value * (5 * dotGapBase.value)
-      ? Math$.gcd(maxGap, dotSize.value * (5 * dotGapBase.value))
-      : Math$.lcm(maxGap, dotSize.value * (5 * dotGapBase.value)),
-    dotSize.value * (4 * dotGapBase.value),
-    dotSize.value * (6 * dotGapBase.value)
-  );
-});
-
-const measureBoundingBox = () => {
-  width.value = wrapperRef$.value?.offsetWidth || 0;
-  height.value = wrapperRef$.value?.offsetHeight || 0;
-};
-
-onMounted(() => {
-  measureBoundingBox();
-});
+const dotGapBase = ref(2);
+const dotGap = computed(() => dotSize.value * (4 * dotGapBase.value));
 </script>
 
 <template>
@@ -43,17 +31,39 @@ onMounted(() => {
     >
       <defs></defs>
       <rect x="0" y="0" width="100%" height="100%" fill="transparent" />
-      <template v-for="x in width / dotGap">
-        <template v-for="y in height / dotGap">
-          <template v-if="x % 2 === 0 && y % 2 === 0">
+      <template
+        v-if="Math.round(width / dotGap) * Math.round(height / dotGap) > 0"
+      >
+        <template v-for="x in Math.round(width / dotGap)">
+          <template
+            v-for="y in Math.round(height / dotGap)"
+            :key="`dot-${x}-${y}`"
+          >
             <path
-              :key="`dot-${x}-${y}`"
-              :d="`
-                M ${(x - 1) * dotGap} ${(y - 1) * dotGap - dotSize / 2}
+              :d="
+                Math$.Vector.delta(
+                  {
+                    x: $mouse.x,
+                    y: $mouse.y
+                  },
+                  {
+                    x: (x - 1) * dotGap,
+                    y: (y - 1) * dotGap
+                  }
+                ) <
+                (dotSize * dotGap) / 2
+                  ? `M ${(x - 1 / 2) * dotGap - dotSize / 2}
+                      ${(y - 1 / 2) * dotGap - dotSize / 2}
+                    l ${dotSize} ${dotSize}
+                    m ${dotSize * -1} 0
+                    l ${dotSize} ${dotSize * -1}`
+                  : `
+                M ${(x - 1 / 2) * dotGap} ${(y - 1 / 2) * dotGap - dotSize / 2}
                 v ${dotSize}
                 m ${dotSize / -2} ${dotSize / -2}
-                h ${dotSize}`"
-              :class="$style['screen-tone--path']"
+                h ${dotSize}`
+              "
+              :class="$style['screen-tone--dot']"
               fill="transparent"
               stroke="currentColor"
               stroke-linecap="round"
@@ -67,6 +77,7 @@ onMounted(() => {
 </template>
 
 <style module lang="scss" scoped>
+@use 'sass:string';
 @use '@/assets/styles/scss/modules/theme.module' as theme;
 
 .screen-tone {
@@ -76,9 +87,10 @@ onMounted(() => {
     height: 100vh;
   }
 
-  &--path {
+  &--dot {
     stroke: #{theme.$screen-tone-dot-color};
     stroke-width: #{theme.$screen-tone-dot-stroke-width};
+    opacity: 0.75;
   }
 }
 </style>

--- a/src/modules/components/Element/ScreenTone.vue
+++ b/src/modules/components/Element/ScreenTone.vue
@@ -54,6 +54,10 @@ onMounted(() => {
                 m ${dotSize / -2} ${dotSize / -2}
                 h ${dotSize}`"
               :class="$style['screen-tone--path']"
+              fill="transparent"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
             />
           </template>
         </template>

--- a/src/modules/components/Element/ScreenTone.vue
+++ b/src/modules/components/Element/ScreenTone.vue
@@ -5,13 +5,13 @@ const wrapperRef$ = ref<HTMLElement>();
 const width = ref(0);
 const height = ref(0);
 
-const calcVariables = () => {
+const measureBoundingBox = () => {
   width.value = wrapperRef$.value?.offsetWidth || 0;
   height.value = wrapperRef$.value?.offsetHeight || 0;
 };
 
 onMounted(() => {
-  calcVariables();
+  measureBoundingBox();
 });
 </script>
 

--- a/src/shared/libs/math.ts
+++ b/src/shared/libs/math.ts
@@ -28,7 +28,7 @@ export type MathProxy = Math & {
  **/
 export const ARC_BASE = Number(0.5522847498307935);
 
-const deltaAsix = <T extends string>(
+const deltaAxis = <T extends string>(
   a: Vector<T>,
   b: Vector<T>,
   axis: keyof Vector<T>,
@@ -41,7 +41,7 @@ const delta = <T extends string>(
   useVector = false
 ): number | Vector<T> => {
   const matrix = Object.keys(a).map((axis) =>
-    deltaAsix(a, b, axis as T, useVector)
+    deltaAxis(a, b, axis as T, useVector)
   );
 
   return useVector

--- a/src/shared/libs/math.ts
+++ b/src/shared/libs/math.ts
@@ -25,6 +25,8 @@ export type MathProxy = Math & {
   deg: (rad: number) => number;
   rad: (deg: number) => number;
   gcd: (a: number, b: number) => number;
+  lcm: (a: number, b: number) => number;
+  clamp: (value: number, min: number, max: number) => number;
 };
 
 /*
@@ -115,6 +117,11 @@ const Math$: MathProxy = new Proxy<MathProxy>(Math as MathProxy, {
     if (prop === 'rad') return (deg: number): number => deg * (Math.PI / 180);
     if (prop === 'gcd')
       return (a: number, b: number): number => (!b ? a : Math$.gcd(b, a % b));
+    if (prop === 'lcm')
+      return (a: number, b: number): number => (a * b) / Math$.gcd(a, b);
+    if (prop === 'clamp')
+      return (value: number, min: number, max: number): number =>
+        Math.min(Math.max(value, min), max);
     return Reflect.get(target, prop, receiver);
   }
 });

--- a/src/shared/libs/math.ts
+++ b/src/shared/libs/math.ts
@@ -4,21 +4,11 @@ import { fromPairs } from 'lodash-es';
 export type MathProxy = Math & {
   ARC_BASE: number;
   Vector: {
-    delta: {
-      (): Record<
-        string,
-        <T extends string>(
-          a: Vector<T>,
-          b: Vector<T>,
-          useVector?: boolean
-        ) => number
-      >;
-      (): <T extends string>(
-        a: Vector<T>,
-        b: Vector<T>,
-        useVector?: boolean
-      ) => number | Vector<T>;
-    };
+    delta: <T extends string>(
+      a: Vector<T>,
+      b: Vector<T>,
+      useVector?: boolean
+    ) => number | Vector<T>;
     add: <T extends string>(a: Vector<T>, b: Vector<T>) => Vector<T>;
     minus: <T extends string>(a: Vector<T>, b: Vector<T>) => Vector<T>;
   };
@@ -72,13 +62,7 @@ const VectorDeltaHandler = {
         b: Vector<T>,
         useVector?: boolean
       ): number | Vector<T> => {
-        if (
-          /delta\.([a-zA-Z_0-9]+)/.exec(prop) &&
-          Object.prototype.hasOwnProperty.call(a, prop) &&
-          Object.prototype.hasOwnProperty.call(b, prop)
-        ) {
-          return deltaAsix(a, b, prop as T, useVector);
-        } else if (prop === 'delta') {
+        if (prop === 'delta') {
           return delta(a, b, useVector);
         }
         return Reflect.get(target, prop, receiver);
@@ -112,7 +96,7 @@ const VectorDeltaHandler = {
 const Math$: MathProxy = new Proxy<MathProxy>(Math as MathProxy, {
   get(target, prop, receiver) {
     if (prop === 'ARC_BASE') return ARC_BASE;
-    if (prop === 'Vector') return VectorDeltaHandler;
+    if (prop === 'Vector') return new Proxy({}, VectorDeltaHandler);
     if (prop === 'deg') return (rad: number): number => rad * (180 / Math.PI);
     if (prop === 'rad') return (deg: number): number => deg * (Math.PI / 180);
     if (prop === 'gcd')

--- a/src/shared/libs/math.ts
+++ b/src/shared/libs/math.ts
@@ -24,6 +24,7 @@ export type MathProxy = Math & {
   };
   deg: (rad: number) => number;
   rad: (deg: number) => number;
+  gcd: (a: number, b: number) => number;
 };
 
 /*
@@ -112,6 +113,8 @@ const Math$: MathProxy = new Proxy<MathProxy>(Math as MathProxy, {
     if (prop === 'Vector') return VectorDeltaHandler;
     if (prop === 'deg') return (rad: number): number => rad * (180 / Math.PI);
     if (prop === 'rad') return (deg: number): number => deg * (Math.PI / 180);
+    if (prop === 'gcd')
+      return (a: number, b: number): number => (!b ? a : Math$.gcd(b, a % b));
     return Reflect.get(target, prop, receiver);
   }
 });


### PR DESCRIPTION
- feat(shared): Add GCD compute method on Math shared library.
- style: Rename to avoid ambiguous function naming.
- feat(shared): Add LCM compute method and clamp function on Math shared library.
- feat(view): Implement screen-tone component with path caculation.
- feat(styles): Add screen-tone properties as variables in theme.
- feat(view): Unified default stroke properties.
- feat(view): Add interactive effect on screen-tone.
- refactor(shared): Deprecate axis vector delta method on Math library.
- fix(typo): Asix -> Axis.
- feat(view): use responsive bounding box on main-frame component.
